### PR TITLE
Fixes #16: update code to use MONGO_URI for env variable

### DIFF
--- a/kim_chat_backend/src/config/db.js
+++ b/kim_chat_backend/src/config/db.js
@@ -2,7 +2,7 @@ let mongoose = require('mongoose');
 
 let connectDataBase = async () => {
     try {
-        await mongoose.connect(process.env.database_url_local);
+        await mongoose.connect(process.env.MONGO_URI);
         console.log("MongoDB Connected");
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
This PR updates the MongoDB connection logic to use `process.env.MONGO_URI` instead of the non-standard `database_url_local`.

`.env` variables are conventionally uppercase, and `MONGO_URI` is clearer and more intuitive for developers. This brings the code in line with common practices.

Fixes #16 